### PR TITLE
Fix setValue and getValue bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ acat_report
 log
 *.log
 .DS_Store
+spike

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "name": "amazon-qldb-kvs-nodejs",
   "description": "A helper module, simplifying basic interactions with Amazon Quantum Ledger Database for Node.js through a simple key-value store interface.",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "devDependencies": {

--- a/src/QLDBKVS.ts
+++ b/src/QLDBKVS.ts
@@ -349,14 +349,16 @@ export class QLDBKVS {
 
                 }
 
-                if (withVersionNumbers) {
-                    returnObjects[index] = {
-                        data: returnValue,
-                        version: valueVersion
-                    }
-                } else {
-                    returnObjects[index] = returnValue
+                returnObjects[index] = {
+                    // Result order is non-deterministic, hence key is returned
+                    key: resultData.get(KEY_ATTRIBUTE_NAME).stringValue(),
+                    data: returnValue,
                 }
+
+                if (withVersionNumbers) {
+                    returnObjects[index].version = valueVersion;
+                }
+
                 if (index === result.length - 1) {
                     return returnObjects;
                 }

--- a/src/UpsertDocument.ts
+++ b/src/UpsertDocument.ts
@@ -69,8 +69,9 @@ export async function upsert(txn: TransactionExecutor, tableName: string, keyAtt
         if (docIdsAndVersions.length == 1) {
             logger.debug(`${fcnName} Document exists, updating.`);
             const documentId: string = docIdsAndVersions[0].id;
-            const documentVersion: number = docIdsAndVersions[0].version;
-            if (version && (version !== documentVersion)) {
+            const documentVersion: number = docIdsAndVersions[0].version;            
+            // Number with value 0 is falsy, so need to check whether it is defined
+            if (Number.isFinite(version) && (version !== documentVersion)) {
                 throw new Error(`Expected version number ${version} does not equal ${documentVersion} the latest version number in the ledger `);
             }
             // Just to be 100% sure we are updating a right document in deterministic way

--- a/test/1.QLDBKVS.Object.test.js
+++ b/test/1.QLDBKVS.Object.test.js
@@ -44,13 +44,13 @@ describe('1.QLDBKVS.Object.test', () => {
     it('Test getValue String', async () => {
         const res = await qldbKVS.getValue(constants.DOC_STRING_KEY);
         console.log(`[TEST LOGS]Test getValue: ${JSON.stringify(res)}`)
-        expect(res).toEqual(constants.DOC_STRING_VALUE)
+        expect(res.data).toEqual(constants.DOC_STRING_VALUE)
     }, 10000);
 
     it('Test getValue Object', async () => {
         const res = await qldbKVS.getValue(constants.DOC_OBJECT_KEY);
         console.log(`[TEST LOGS]Test getValue: ${JSON.stringify(res)}`)
-        expect(res).toEqual(constants.DOC_OBJECT_VALUE)
+        expect(res.data).toEqual(constants.DOC_OBJECT_VALUE)
     }, 10000);
 
     it('Test catching rejection from getValue for non-existing Object', async () => {

--- a/test/2.QLDBKVS.Objects.test.js
+++ b/test/2.QLDBKVS.Objects.test.js
@@ -64,13 +64,19 @@ describe('2.QLDBKVS.Objects.test', () => {
     it('Test getValues', async () => {
         const res = await qldbKVS.getValues([constants.DOC_STRING_KEY, constants.DOC_OBJECT_KEY]);
         console.log(`[TEST LOGS]Test getValues: ${JSON.stringify(res)}`)
-        expect(res).toEqual(expect.arrayContaining([constants.DOC_OBJECT_VALUE, constants.DOC_STRING_VALUE]))
+        const resultDataArray = res.map((result) => {
+            return result.data
+        })
+        expect(resultDataArray).toEqual(expect.arrayContaining([constants.DOC_OBJECT_VALUE, constants.DOC_STRING_VALUE]))
     }, 10000);
 
     it('Test getValues one value does not exist', async () => {
         const res = await qldbKVS.getValues([constants.DOC_STRING_KEY, "noKey"]);
         console.log(`[TEST LOGS]Test getValues: ${JSON.stringify(res)}`)
-        expect(res).toEqual([constants.DOC_STRING_VALUE])
+        const resultDataArray = res.map((result) => {
+            return result.data
+        })
+        expect(resultDataArray).toEqual([constants.DOC_STRING_VALUE])
     }, 10000);
 
     it('Test getValues with versions', async () => {
@@ -102,7 +108,19 @@ describe('2.QLDBKVS.Objects.test', () => {
     }, 20000);
 
     it('Test setValues Object and String with correct versions', async () => {
-        const res = await qldbKVS.setValues([constants.DOC_OBJECT_KEY, constants.DOC_STRING_KEY], [constants.DOC_OBJECT_VALUE, constants.DOC_STRING_VALUE], versionsArray);
+
+        const getValuesWithVersionRes = await qldbKVS.getValues([constants.DOC_OBJECT_KEY, constants.DOC_STRING_KEY], true);
+        const resultVersionsArray = getValuesWithVersionRes.map((result) => {
+            return result.version
+        });
+        const resultKeysArray = getValuesWithVersionRes.map((result) => {
+            return result.key
+        })
+        const resultDataArray = getValuesWithVersionRes.map((result) => {
+            return result.data
+        });
+
+        const res = await qldbKVS.setValues(resultKeysArray, resultDataArray, resultVersionsArray);
         console.log(`[TEST LOGS]Test setValues Object and String with correct versions: ${JSON.stringify(res)}`)
         expect(res).toBeTruthy();
     }, 20000);


### PR DESCRIPTION
*Description of changes:*

**Bug 1**
```
await qldbKVS.getValues([constants.DOC_OBJECT_KEY, constants.DOC_STRING_KEY], true);
```
This does not guarantee the order of the result. Even though I queried ['myKey25', 'ald', 'myKey1'], but the result comes in the order of ['ald', 'myKey1', 'myKey25'] . However, in [QLDBKVS.getValues](https://github.com/aws-samples/amazon-qldb-kvs-nodejs/blob/2ef53e5e33006c43dce6bb21c23faea7eccef360/src/QLDBKVS.ts#L330) , the key is not inserted in the return value, so we cannot know deterministically which value belong to which key. So I passed the keys too in the result

**Bug 2**

If i supply the version as 0 like such,
```
qldbKVS.setValues([constants.DOC_OBJECT_KEY, constants.DOC_STRING_KEY], [constants.DOC_OBJECT_VALUE, constants.DOC_STRING_VALUE], [0,0])
```

the check [here](https://github.com/aws-samples/amazon-qldb-kvs-nodejs/blob/2ef53e5e33006c43dce6bb21c23faea7eccef360/src/UpsertDocument.ts#L73) is bypassed, because 0 is actually falsy in javascript. So I used `Number.isFinite()` function instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
